### PR TITLE
修复行展开错误

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -669,11 +669,15 @@ function registerComponent (vxetable: typeof VXETable) {
           if (rowIndex === -1) {
             throw new Error('错误的操作！')
           }
-          XEUtils.eachTree(childRows, (item, index, obj, paths, parent, nodes) => {
-            if (!parent || parent._X_EXPAND) {
-              expandList.push(item)
+          function deepExpandRow(childRows: any) {
+            for (const row of childRows) {
+              expandList.push(row)
+              if (row._X_EXPAND) {
+                deepExpandRow(row[treeOpts.children])
+              }
             }
-          }, treeOpts)
+          }
+          deepExpandRow(childRows)
           row._X_EXPAND = true
           treeTableData.splice.apply(treeTableData, [rowIndex + 1, 0].concat(expandList))
         }


### PR DESCRIPTION
该PR修复了当子节点的父节点的属性 _X_EXPAND 为 true, 而父节点的某个祖先节点的属性 _X_EXPAND 为 false 时 , 子节点被错误展开的问题.

Issue https://github.com/x-extends/vxe-table-plugin-virtual-tree/issues/12